### PR TITLE
Shophand Subclasses and Spellthief for Mage

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -397,6 +397,7 @@ GLOBAL_LIST_EMPTY(round_join_times)
 #define CTAG_PILGRIM 		"CAT_PILGRIM"  		// Pilgrim classes
 #define CTAG_ADVENTURER 	"CAT_ADVENTURER"  	// Adventurer classes
 #define CTAG_TOWNER 		"CAT_TOWNER"  		// Villager class - Villagers can use it
+#define CTAG_SHOPHAND		"CAT_SHOPHAND"		// Shophand classes
 #define CTAG_ANTAG 			"CAT_ANTAG"  		// Antag class - results in an antag
 #define CTAG_BANDIT			"CAT_BANDIT"		// Bandit class - Tied to the bandit antag really
 #define CTAG_CHALLENGE 		"CAT_CHALLENGE"  	// Challenge class - Meant to be free for everyone

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -8,12 +8,13 @@
 	traits_applied = list(TRAIT_OUTLANDER)
 	classes = list("Sorcerer" = "You are a learned mage and a scholar, having spent your life studying the arcane and its ways.", 
 					"Spellblade" = "You are skilled in both the arcyne art and swordsmanship. But you are not a master of either nor could you channel your magick in armor.",			
-					"Spellsinger" = "You belong to a school of bards renowned for their study of both the arcane and the arts.")
+					"Spellsinger" = "You belong to a school of bards renowned for their study of both the arcane and the arts.",
+					"Spellthief" = "You are a back-alley thief who fell from their magical tutelage, or has stolen Noc's gift to further their own larceny.")
 
 /datum/outfit/job/roguetown/adventurer/mage/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.adjust_blindness(-3)
-	var/classes = list("Sorcerer", ,"Spellblade", "Spellsinger")
+	var/classes = list("Sorcerer", ,"Spellblade", "Spellsinger", "Spellthief")
 	var/classchoice = input("Choose your archetypes", "Available archetypes") as anything in classes
 
 	switch(classchoice)
@@ -184,3 +185,58 @@
 					backr = /obj/item/rogue/instrument/viola
 				if("Vocal Talisman")
 					backr = /obj/item/rogue/instrument/vocals
+		if("Spellthief")
+			to_chat(H, span_warning("You are a rogue, either by choice or hardship. Your study of the arcyne knowledge, stolen or not, now aids in your roguish endeavors."))
+			armor = /obj/item/clothing/suit/roguetown/armor/leather
+			backl = /obj/item/storage/backpack/rogue/backpack
+			backr = /obj/item/gun/ballistic/revolver/grenadelauncher/bow
+			shoes = /obj/item/clothing/shoes/roguetown/boots
+			neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+			belt = /obj/item/storage/belt/rogue/leather
+			beltl = /obj/item/quiver/Warrows
+			beltr = /obj/item/rogueweapon/mace/cudgel
+			gloves = /obj/item/clothing/gloves/roguetown/fingerless
+			pants = /obj/item/clothing/under/roguetown/trou/leather
+			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+			cloak = /obj/item/clothing/cloak/raincloak/mortus
+			backpack_contents = list(
+				/obj/item/flashlight/flare/torch = 1,
+				/obj/item/rogueweapon/huntingknife/idagger/steel = 1,
+				/obj/item/lockpickring/mundane = 1,
+				/obj/item/recipe_book/survival = 1,
+				/obj/item/rogueweapon/scabbard/sheath = 1
+				)
+			if(H.mind)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/invisibility)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/lesserknock)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/fetch)
+			H.adjust_skillrank(/datum/skill/misc/tracking, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/lockpicking, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/traps, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
+			H.change_stat("strength", -1)
+			H.change_stat("intelligence", 2)
+			H.change_stat("perception", 1)
+			H.change_stat("endurance", 1)
+			H.change_stat("speed", 2)
+			H.cmode_music = 'sound/music/combat_rogue.ogg'
+			switch(H.patron?.type)
+				if(/datum/patron/inhumen/zizo)
+					H.cmode_music = 'sound/music/combat_cult.ogg'
+			H.grant_language(/datum/language/thievescant)
+			H?.mind.adjust_spellpoints(12)
+			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_ARCYNE_T2, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/shophand.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/shophand.dm
@@ -9,35 +9,215 @@
 	allowed_races = RACES_ALL_KINDS
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT)
-
-	tutorial = "You work the largest store in the Peaks by grace of the Merchant who has shackled you to this drudgery. The work of stocking shelves and taking inventory for your employer is mind-numbing and repetitive--but at least you have a roof over your head and comfortable surroundings. With time, perhaps you will one day be more than a glorified servant."
-
-	outfit = /datum/outfit/job/roguetown/shophand
+	advclass_cat_rolls = list(CTAG_SHOPHAND = 20)
+	tutorial = "You work the largest store in the Peaks by the grace of the Merchant who has shackled you in service to the Merchant's Guild. You do as you are told and in return are rewarded with meager pay and a roof above your head. With time, perhaps you will one day be more than a glorified servant."
+//"You work the largest store in the Peaks by grace of the Merchant who has shackled you to this drudgery. The work of stocking shelves and taking inventory for your employer is mind-numbing and repetitive--but at least you have a roof over your head and comfortable surroundings. With time, perhaps you will one day be more than a glorified servant."
+	//outfit = /datum/outfit/job/roguetown/shophand
 	display_order = JDO_SHOPHAND
 	give_bank_account = TRUE
 	min_pq = -10
 	max_pq = null
 	round_contrib_points = 2
 
-/datum/outfit/job/roguetown/shophand/pre_equip(mob/living/carbon/human/H)
+/datum/job/roguetown/shophand/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	..()
+	if(L)
+		var/mob/living/carbon/human/H = L
+		H.advsetup = 1
+		H.invisibility = INVISIBILITY_MAXIMUM
+		H.become_blind("advsetup")
+
+/datum/advclass/guildthug
+	name = "Guild Thug"
+	tutorial = "You've been hired by the Merchant's Guild to be their brawn. Valued for your strength and little else, you assist the Merchant in hauling heavy goods, or strong arming potential thiefs."
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = RACES_ALL_KINDS
+	outfit = /datum/outfit/job/roguetown/adventurer/guildthug
+	category_tags = list(CTAG_SHOPHAND)
+
+/datum/outfit/job/roguetown/adventurer/guildthug/pre_equip(mob/living/carbon/human/H)
+	..()
+	H.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/unarmed, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/climbing, 4, TRUE) 
+	H.adjust_skillrank(/datum/skill/labor/mining, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/labor/lumberjacking, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/labor/fishing, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/sneaking, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/stealing, 1, TRUE)
+	var/weapons = list("Knuckles","Cudgel")
+	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+	H.set_blindness(0)
+	switch(weapon_choice)
+		if("Knuckles")
+			beltr = /obj/item/rogueweapon/knuckles/bronzeknuckles
+		if("Cudgel")
+			beltl = /obj/item/rogueweapon/mace/cudgel
+	head = /obj/item/clothing/head/roguetown/roguehood/shalal/heavyhood
+	belt = /obj/item/storage/belt/rogue/leather
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	backl = /obj/item/storage/backpack/rogue/satchel
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	gloves = /obj/item/clothing/gloves/roguetown/fingerless
+	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat
+	backpack_contents = list(
+				/obj/item/flashlight/flare/torch = 1,
+				/obj/item/rogueweapon/huntingknife = 1,
+				/obj/item/rogueweapon/scabbard/sheath = 1,
+				/obj/item/storage/keyring/merchant = 1,
+				)
+	H.change_stat("strength", 2)
+	H.change_stat("endurance", 1)
+	H.change_stat("constitution", 3)
+	H.change_stat("intelligence", -1)
+	H.grant_language(/datum/language/thievescant)
 	ADD_TRAIT(H, TRAIT_SEEPRICES_SHITTY, "[type]")
-	if(should_wear_femme_clothes(H))
-		pants = /obj/item/clothing/under/roguetown/tights
-		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/blue
-		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
-		belt = /obj/item/storage/belt/rogue/leather
-		beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
-		beltl = /obj/item/storage/keyring/merchant
-		backr = /obj/item/storage/backpack/rogue/satchel
-	else if(should_wear_masc_clothes(H))
-		pants = /obj/item/clothing/under/roguetown/tights
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
-		shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
-		belt = /obj/item/storage/belt/rogue/leather
-		beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
-		beltl = /obj/item/storage/keyring/merchant
-		backr = /obj/item/storage/backpack/rogue/satchel
+	if(H.mind)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
+
+/datum/advclass/guildinformant
+	name = "Guild Informant"
+	tutorial = "You started as a basic street urchin sneaking and stealing as you needed. On one fateful day you chose to steal from the Merchant's Guild, and now find yourself indebted to their service. Now, you serve as their eyes and ears on the streets of the city."
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = RACES_ALL_KINDS
+	outfit = /datum/outfit/job/roguetown/adventurer/guildinformant
+	category_tags = list(CTAG_SHOPHAND)
+
+/datum/outfit/job/roguetown/adventurer/guildinformant/pre_equip(mob/living/carbon/human/H)
+	..()
+	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/climbing, 4, TRUE) 
+	H.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/lockpicking, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+	belt = /obj/item/storage/belt/rogue/leather
+	beltl = /obj/item/rogueweapon/mace/cudgel
+	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	backl = /obj/item/storage/backpack/rogue/satchel
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
+	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+	armor = /obj/item/clothing/suit/roguetown/armor/leather
+	cloak = /obj/item/clothing/cloak/raincloak/mortus
+	backpack_contents = list(
+				/obj/item/flashlight/flare/torch = 1,
+				/obj/item/rogueweapon/huntingknife/idagger/steel = 1,
+				/obj/item/rogueweapon/scabbard/sheath = 1,
+				/obj/item/storage/keyring/merchant = 1,
+				)
+	H.change_stat("speed", 3)
+	H.change_stat("endurance", 1)
+	H.change_stat("constitution", 1)
+	H.change_stat("intelligence", 1)
+	H.grant_language(/datum/language/thievescant)
+	ADD_TRAIT(H, TRAIT_SEEPRICES_SHITTY, "[type]")
+	if(H.mind)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
+
+/datum/advclass/hiredservant
+	name = "Hired Servant"
+	tutorial = "You are an expert courtier, though find yourself in the service to an aristocrat rather than nobility. Your ability to cater to your Merchant's needs are unparalleled."
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = RACES_ALL_KINDS
+	outfit = /datum/outfit/job/roguetown/adventurer/hiredservant
+	category_tags = list(CTAG_SHOPHAND)
+
+/datum/outfit/job/roguetown/adventurer/hiredservant/pre_equip(mob/living/carbon/human/H)
+	..()
+	backr = /obj/item/storage/backpack/rogue/satchel
+	backpack_contents = list(
+				/obj/item/kitchen/rollingpin = 1,
+				/obj/item/flint = 1,
+				/obj/item/cooking/pan = 1,
+				/obj/item/reagent_containers/peppermill = 1,
+			)
+	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/storage/keyring/merchant
+	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
+	r_hand = /obj/item/reagent_containers/glass/bucket/pot
+	var/loadouts = list("Maid","Butler")
+	var/loadout_choice = input("Choose your attire.") as anything in loadouts
+	H.set_blindness(0)
+	switch(loadout_choice)
+		if("Maid")
+			head = /obj/item/clothing/head/roguetown/armingcap
+			armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/black
+			shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
+			pants = /obj/item/clothing/under/roguetown/tights/stockings/black
+			cloak = /obj/item/clothing/cloak/apron/waist
+		if("Butler")
+			pants = /obj/item/clothing/under/roguetown/tights/black
+			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+			shoes = /obj/item/clothing/shoes/roguetown/shortboots
+			armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
+	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/cooking, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/sewing, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/lockpicking, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/labor/farming, 3, TRUE)
+	H.change_stat("speed", 1)
+	H.change_stat("intelligence", 1)
+	H.change_stat("perception", 2)
+	ADD_TRAIT(H, TRAIT_CICERONE, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_SEEPRICES_SHITTY, "[type]")
+	if(H.mind)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
+
+//The original version of the shophand
+/datum/advclass/shoplackey
+	name = "Shop Lackey"
+	tutorial = "You were once a beggar on the street struggling to find your next meal. The Merchant's Guild offered you a roof in exchange for your labor. Now you find yourself as little more than an indentured servant to the Merchant and their whims."
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = RACES_ALL_KINDS
+	outfit = /datum/outfit/job/roguetown/adventurer/shoplackey
+	category_tags = list(CTAG_SHOPHAND)
+
+/datum/outfit/job/roguetown/adventurer/shoplackey/pre_equip(mob/living/carbon/human/H)
+	..()
+	var/loadouts = list("Shirt","Dress")
+	var/loadout_choice = input("Choose your attire.") as anything in loadouts
+	H.set_blindness(0)
+	switch(loadout_choice)
+		if("Dress")
+			pants = /obj/item/clothing/under/roguetown/tights
+			armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/blue
+			shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
+			belt = /obj/item/storage/belt/rogue/leather
+			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
+			beltl = /obj/item/storage/keyring/merchant
+			backr = /obj/item/storage/backpack/rogue/satchel
+		if("Shirt")
+			pants = /obj/item/clothing/under/roguetown/tights
+			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
+			shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
+			belt = /obj/item/storage/belt/rogue/leather
+			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
+			beltl = /obj/item/storage/keyring/merchant
+			backr = /obj/item/storage/backpack/rogue/satchel
 	//worse skills than a normal peasant, generally, with random bad combat skill
 	H.adjust_skillrank(/datum/skill/misc/stealing, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
@@ -52,6 +232,7 @@
 	H.change_stat("speed", 1)
 	H.change_stat("intelligence", 1)
 	H.change_stat("fortune", 1)
+	ADD_TRAIT(H, TRAIT_SEEPRICES_SHITTY, "[type]")
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
 	if(prob(33))


### PR DESCRIPTION
## About The Pull Request
- Shophand gains four new subclasses: Guild Thug, Guild Informant, Hired Servant, and Shop Lackey
- Adds Spellthief as a roguish subclass of Mage

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
## Why It's Good For The Game
More Class diversity makes for more fun character opportunities and builds.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
