### PR TITLE
Disables Major Stress Messages and Events

### DIFF
--- a/code/modules/mob/living/carbon/stress.dm
+++ b/code/modules/mob/living/carbon/stress.dm
@@ -1,4 +1,4 @@
-GLOBAL_LIST_INIT(stress_messages, world.file2list("strings/rt/stress_messages.txt"))
+//GLOBAL_LIST_INIT(stress_messages, world.file2list("strings/rt/stress_messages.txt"))
 
 /mob/proc/add_stress(event_type)
 	return
@@ -124,13 +124,13 @@ GLOBAL_LIST_INIT(stress_messages, world.file2list("strings/rt/stress_messages.tx
 				play_mental_break_indicator()
 				apply_status_effect(/datum/status_effect/mood/vbad)
 
-	if(new_stress >=13)
+	/*if(new_stress >=13)
 		if(!HAS_TRAIT(src, TRAIT_EORAN_CALM) && !HAS_TRAIT(src, TRAIT_EORAN_SERENE))
 			random_stress_message()
 
 	if(new_stress >= 20)
 		if(!HAS_TRAIT(src, TRAIT_EORAN_CALM) && !HAS_TRAIT(src, TRAIT_EORAN_SERENE))
-			roll_streak_freakout()
+			roll_streak_freakout()*/
 
 	oldstress = new_stress
 	update_stress_visual(new_stress)
@@ -176,7 +176,7 @@ GLOBAL_LIST_INIT(stress_messages, world.file2list("strings/rt/stress_messages.tx
 
 	update_client_colour()
 
-/mob/living/carbon/proc/roll_streak_freakout()
+/*/mob/living/carbon/proc/roll_streak_freakout()
 	if(stat != CONSCIOUS)
 		return
 	if(mob_timers["next_stress_freakout"])
@@ -186,7 +186,7 @@ GLOBAL_LIST_INIT(stress_messages, world.file2list("strings/rt/stress_messages.tx
 		return
 	// Randomized cooldown
 	mob_timers["next_stress_freakout"] = world.time + rand(60 SECONDS, 120 SECONDS)
-	stress_freakout()
+	stress_freakout()*/
 
 /mob/living/carbon/proc/stress_freakout()
 	to_chat(src, span_boldred("I PANIC!!!"))
@@ -215,13 +215,13 @@ GLOBAL_LIST_INIT(stress_messages, world.file2list("strings/rt/stress_messages.tx
 		animate(whole_screen, transform = newmatrix, time = 1, easing = QUAD_EASING)
 		animate(transform = -newmatrix, time = 30, easing = QUAD_EASING)
 
-/mob/living/carbon/proc/random_stress_message()
+/*/mob/living/carbon/proc/random_stress_message()
 	if(mob_timers["next_stress_message"])
 		if(world.time < mob_timers["next_stress_message"])
 			return
 	mob_timers["next_stress_message"] = world.time + rand(80 SECONDS, 160 SECONDS) //not as important as freakout
 	var/stress_message_picked = pick(GLOB.stress_messages)
-	to_chat(client, span_danger("<b>[stress_message_picked]</b>"))
+	to_chat(client, span_danger("<b>[stress_message_picked]</b>"))*/
 
 
 /mob/living/carbon/get_stress_amount()


### PR DESCRIPTION
## About The Pull Request
Comments out the particularly grimdark stress messages and freakout events.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
## Why It's Good For The Game
A dark world is fine, though not everyone is superb at managing stress levels, so when this...

<img width="442" height="54" alt="image" src="https://github.com/user-attachments/assets/a09ca248-7b6e-4be7-96b0-240c831ea1e4" />

pops up in people's chat logs, it kills the vibe we're trying to maintain.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
