### PR TITLE
Puts the ghost where the prey dies

### DIFF
--- a/modular_causticcove/code/modules/vore/eating/belly_obj.dm
+++ b/modular_causticcove/code/modules/vore/eating/belly_obj.dm
@@ -511,6 +511,9 @@
 
 	// Delete the digested mob
 	release_specific_contents_digest(M)
+	var/mob/dead/observer/G = M.ghostize(FALSE)
+	if(G)
+		G.forceMove(owner)
 	M.x = 1
 	M.y = 1
 	M.z = 1


### PR DESCRIPTION
## About The Pull Request

When the prey dies, generate a ghost for them and force move it onto the predator's position

## Testing Evidence
Step 1:
<img width="414" height="361" alt="image" src="https://github.com/user-attachments/assets/6971209f-c035-4634-8165-ce0705d3516d" />
Step 2:
<img width="460" height="404" alt="image" src="https://github.com/user-attachments/assets/59d719c5-70b4-4409-a79e-7790806066cc" />


## Why It's Good For The Game

Apparently this was a requested feature, or so Cain told me?
