### PR TITLE
Gives head prices to carbon skeletons and Drow

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/drow.dm
+++ b/code/modules/mob/living/carbon/human/npc/drow.dm
@@ -91,6 +91,7 @@ GLOBAL_LIST_INIT(drowraider_aggro, world.file2list("strings/rt/drowaggrolines.tx
 		real_name = pick(world.file2list("strings/rt/names/elf/elfdm.txt"))
 	update_hair()
 	update_body()
+	head.sellprice = 40 // Drow are dangerous! They're also dangerous to get to and, depending on location, like to run into acid vats. This accounts for that.
 
 /mob/living/carbon/human/species/elf/dark/drowraider/npc_idle()
 	if(m_intent == MOVE_INTENT_SNEAK)

--- a/code/modules/mob/living/carbon/human/npc/skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton.dm
@@ -83,6 +83,8 @@
 		var/datum/outfit/OU = new skel_outfit
 		if(OU)
 			equipOutfit(OU)
+	var/obj/item/bodypart/head = get_bodypart(BODY_ZONE_HEAD)
+	head.sellprice = 20 //there's a LOT of these guys. May later change head prices depending on skeletype. Dread knights > nakeds.
 
 /datum/outfit/job/roguetown/npc/skeleton/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
## About The Pull Request

Changes:
- Drow heads now have a sellprice of 40 (They're dangerous, and hard to get to)
- Carbon type skeleton heads now have a sellprice of 20 (There's a ton of them.)
Note: I plan on tackling orcs separately, as they're simplemobs.
## Testing Evidence
Drow Head Test
<img width="608" height="603" alt="image" src="https://github.com/user-attachments/assets/f7256031-053d-48d8-8ced-1214d8e69124" />
Skeleton Head Test
<img width="581" height="54" alt="image" src="https://github.com/user-attachments/assets/071688b9-4e50-47b7-914f-0508ab5f4f77" />

## Why It's Good For The Game

Gives Headhooks more use, and incentivizes more teamwork to take on drow for the profit, or, at the very least, for headhunters to have more options.