### PR TITLE
Fixes reform portals

### DIFF
--- a/modular_causticcove/code/modules/vore/eating/belly_obj.dm
+++ b/modular_causticcove/code/modules/vore/eating/belly_obj.dm
@@ -511,7 +511,7 @@
 
 	// Delete the digested mob
 	release_specific_contents_digest(M)
-	var/mob/dead/observer/G = M.ghostize(FALSE)
+	var/mob/dead/observer/G = M.ghostize(TRUE)
 	if(G)
 		G.forceMove(owner)
 	M.x = 1


### PR DESCRIPTION
## About The Pull Request

Due to an oversight in my testing, I failed to take into account that reform portals are simply just rejuving a mob and putting the ghost back into them, so I have set the return to body option to false. This PR corrects that, returning the ability to reform after digestion.

## Testing Evidence

Got eaten, digested, and was able to reform

## Why It's Good For The Game

Bugs le bad
