### PR TITLE
Scooping up now toggles rest to standing up before being picked up

### DIFF
--- a/modular_causticcove/code/modules/micromacrointeractions/scoop.dm
+++ b/modular_causticcove/code/modules/micromacrointeractions/scoop.dm
@@ -3,8 +3,8 @@
 		return FALSE
 	if(!can_be_picked_up(grabby))
 		return FALSE
-	var/obj/item/micro/friend = new /obj/item/micro(get_turf(grabby), src)
 	friend.set_resting(FALSE,FALSE)
+	var/obj/item/micro/friend = new /obj/item/micro(get_turf(grabby), src)
 	grabby.put_in_hands(friend)
 	to_chat(grabby, span_notice("You scoop up \the [src]!"))
 	to_chat(src, span_notice("\The [grabby] scoops you up!"))

--- a/modular_causticcove/code/modules/micromacrointeractions/scoop.dm
+++ b/modular_causticcove/code/modules/micromacrointeractions/scoop.dm
@@ -4,6 +4,7 @@
 	if(!can_be_picked_up(grabby))
 		return FALSE
 	var/obj/item/micro/friend = new /obj/item/micro(get_turf(grabby), src)
+	friend.set_resting(FALSE,FALSE)
 	grabby.put_in_hands(friend)
 	to_chat(grabby, span_notice("You scoop up \the [src]!"))
 	to_chat(src, span_notice("\The [grabby] scoops you up!"))


### PR DESCRIPTION
## About The Pull Request

Before being picked up, it forcibly sets your rest to false, HOPEFULLY preventing a transform bug. Reported by Tiktok! Thank you!

## Testing Evidence

Couldn't reproduce, so only hoping this fixes it, in theory it should

## Why It's Good For The Game

Bugs le bad
