### PR TITLE
Makes stone hoes repairable

### DIFF
--- a/code/modules/farming/tools.dm
+++ b/code/modules/farming/tools.dm
@@ -140,7 +140,7 @@
 	icon_state = "stonehoe"
 	//dropshrink = 0.8
 	smeltresult = null
-	anvilrepair = null
+	anvilrepair = /datum/skill/craft/blacksmithing
 	max_integrity = 100
 	hoe_damage = 25
 	work_time = 15 SECONDS


### PR DESCRIPTION
## About The Pull Request

As of now you get 4 tills out of your stone hoes and then they break, forcing you to make a new one, annoying!
<img width="176" height="69" alt="image" src="https://github.com/user-attachments/assets/0e6b7730-925b-435c-b640-394859501abb" />


## Testing Evidence

<img width="226" height="284" alt="image" src="https://github.com/user-attachments/assets/14f92b07-b30d-4856-8950-3eae0e3f7dc5" />

## Why It's Good For The Game

A nice source of blacksmithing experience since that skill is so hard to level from zero, also makes it so that you don't have like 50 stone hoes laying around in the wilderness.
